### PR TITLE
feat: PWA mobile installation helper and custom UI prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ test-results/
 # Local libraries
 public/libs/
 public/models/
+
+# Superpowers
+.superpowers/
+docs/superpowers/

--- a/e2e/pwa/install-prompt.spec.ts
+++ b/e2e/pwa/install-prompt.spec.ts
@@ -54,7 +54,24 @@ test.describe('PWA Install Prompt', () => {
     await expect(page.locator('.PWAInstallPrompt')).not.toBeVisible();
   });
 
-  test('install button in header exists when beforeinstallprompt is available', async ({ page }) => {
+  test('prompt has correct accessibility attributes', async ({ page }) => {
+    await page.goto('./');
+    const input = page.getByRole('textbox');
+    await input.fill('77');
+    await input.press('Enter');
+
+    await expect(page.locator('.Results')).toBeVisible();
+    await expect(page.locator('.PWAInstallPrompt')).toBeVisible({ timeout: 5000 });
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-label');
+
+    const closeButton = page.locator('.PWAInstallPrompt-Close');
+    await expect(closeButton).toHaveAttribute('aria-label');
+  });
+
+  test('install button in header has correct accessibility', async ({ page }) => {
     await page.addInitScript(() => {
       window.addEventListener('beforeinstallprompt', (e) => {
         e.preventDefault();
@@ -63,12 +80,14 @@ test.describe('PWA Install Prompt', () => {
     });
 
     await page.goto('./');
-
     await page.evaluate(() => {
       window.dispatchEvent(new Event('beforeinstallprompt'));
     });
 
-    await expect(page.locator('.Header-InstallButton')).toBeVisible();
+    const installButton = page.locator('.Header-InstallButton');
+    await expect(installButton).toBeVisible();
+    await expect(installButton).toHaveAttribute('aria-label');
+    await expect(installButton).toHaveAttribute('title');
   });
 
   test('install button in header is hidden when app is already installed', async ({ page }) => {

--- a/e2e/pwa/install-prompt.spec.ts
+++ b/e2e/pwa/install-prompt.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('PWA Install Prompt', () => {
+  test('prompt is hidden before any user action', async ({ page }) => {
+    await page.goto('./');
+    await expect(page.locator('.PWAInstallPrompt')).not.toBeVisible();
+  });
+
+  test('prompt appears after successful search', async ({ page }) => {
+    await page.goto('./');
+    const input = page.getByRole('textbox');
+    await input.fill('77');
+    await input.press('Enter');
+
+    await expect(page.locator('.Results')).toBeVisible();
+
+    // Prompt should appear after 1s delay (setTimeout in App.tsx)
+    await expect(page.locator('.PWAInstallPrompt')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('close button hides prompt and saves dismissed flag', async ({ page }) => {
+    await page.goto('./');
+    const input = page.getByRole('textbox');
+    await input.fill('77');
+    await input.press('Enter');
+
+    await expect(page.locator('.Results')).toBeVisible();
+    await expect(page.locator('.PWAInstallPrompt')).toBeVisible({ timeout: 5000 });
+
+    await page.locator('.PWAInstallPrompt-Close').click();
+    await expect(page.locator('.PWAInstallPrompt')).not.toBeVisible();
+
+    const dismissed = await page.evaluate(() =>
+      localStorage.getItem('pwa_install_dismissed')
+    );
+    expect(dismissed).toBe('true');
+  });
+
+  test('prompt does not reappear after dismissal on reload', async ({ page }) => {
+    await page.goto('./');
+    await page.evaluate(() =>
+      localStorage.setItem('pwa_install_dismissed', 'true')
+    );
+    await page.reload();
+
+    const input = page.getByRole('textbox');
+    await input.fill('77');
+    await input.press('Enter');
+
+    await expect(page.locator('.Results')).toBeVisible();
+
+    // Prompt should NOT appear
+    await page.waitForTimeout(3000);
+    await expect(page.locator('.PWAInstallPrompt')).not.toBeVisible();
+  });
+
+  test('install button in header exists when beforeinstallprompt is available', async ({ page }) => {
+    await page.addInitScript(() => {
+      window.addEventListener('beforeinstallprompt', (e) => {
+        e.preventDefault();
+        (window as unknown as Record<string, unknown>).__deferredPrompt = e;
+      });
+    });
+
+    await page.goto('./');
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event('beforeinstallprompt'));
+    });
+
+    await expect(page.locator('.Header-InstallButton')).toBeVisible();
+  });
+
+  test('install button in header is hidden when app is already installed', async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(window, 'matchMedia', {
+        value: (query: string) => ({
+          matches: query === '(display-mode: standalone)',
+          media: query,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+        }),
+      });
+    });
+
+    await page.goto('./');
+    await expect(page.locator('.Header-InstallButton')).not.toBeVisible();
+  });
+});

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useCallback, useContext } from 'react';
+import React, { useState, useCallback, useContext, useEffect, useRef } from 'react';
 import './App.css';
 
 import Header from '../components/Header/Header';
 import LookupPanel from '../components/LookupPanel/LookupPanel';
 import CameraScanner from '../components/CameraScanner/CameraScanner';
+import PWAInstallPrompt from '../components/PWAInstallPrompt/PWAInstallPrompt';
 
 import { IData } from '../interfaces';
 import LanguageContext from '../contexts/LanguageContext';
@@ -23,6 +24,10 @@ const App: React.FC<AppProps> = ({ data }) => {
   const [showFlags, setShowFlags] = useState(true);
   const [isScannerOpen, setIsScannerOpen] = useState(false);
   const [scannedPlate, setScannedPlate] = useState('');
+  const [firstActionDone, setFirstActionDone] = useState(false);
+  const [promptVisible, setPromptVisible] = useState(false);
+
+  const prevScannedPlateRef = useRef('');
 
   const { originalList } = useRegionData(data);
 
@@ -46,6 +51,32 @@ const App: React.FC<AppProps> = ({ data }) => {
   const handleCapture = useCallback((plate: string) => {
     setScannedPlate(plate);
     setIsScannerOpen(false);
+  }, []);
+
+  const handleFirstAction = useCallback(() => {
+    if (!firstActionDone) {
+      setFirstActionDone(true);
+    }
+  }, [firstActionDone]);
+
+  // Show prompt when first action completes (small delay so user sees results first)
+  useEffect(() => {
+    if (firstActionDone && !promptVisible) {
+      const timer = setTimeout(() => setPromptVisible(true), 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [firstActionDone, promptVisible]);
+
+  // Trigger on camera scan success
+  useEffect(() => {
+    if (scannedPlate && scannedPlate !== prevScannedPlateRef.current) {
+      prevScannedPlateRef.current = scannedPlate;
+      handleFirstAction();
+    }
+  }, [scannedPlate, handleFirstAction]);
+
+  const handlePromptClose = useCallback(() => {
+    setPromptVisible(false);
   }, []);
 
   return (
@@ -95,6 +126,7 @@ const App: React.FC<AppProps> = ({ data }) => {
           onActiveChange={setIsActive}
           externalQuery={scannedPlate}
           onScanClick={handleScanClick}
+          onMatchFound={handleFirstAction}
         />
       </main>
 
@@ -104,6 +136,11 @@ const App: React.FC<AppProps> = ({ data }) => {
           onCapture={handleCapture}
         />
       )}
+
+      <PWAInstallPrompt
+        visible={promptVisible}
+        onClose={handlePromptClose}
+      />
     </div>
   );
 };

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -46,12 +46,51 @@
   gap: 1rem;
 }
 
+.Header-InstallButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-surface-soft);
+  color: var(--color-accent);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  backdrop-filter: blur(8px);
+  white-space: nowrap;
+}
+
+.Header-InstallButton:hover {
+  border-color: var(--color-accent);
+  transform: translateY(-1px);
+}
+
+.Header-InstallButton:active {
+  transform: translateY(0);
+}
+
+.Header-InstallButtonIcon {
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.Header-InstallButtonLabel {
+  font-size: 0.8125rem;
+}
+
 @media (max-width: 720px) {
   .Header-Container {
     padding: 0 1rem;
   }
   
   .Header-Name {
+    display: none;
+  }
+
+  .Header-InstallButtonLabel {
     display: none;
   }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,8 +2,15 @@ import React from 'react';
 import './Header.css';
 import ThemeToggle from '../ThemeToggle/ThemeToggle';
 import LanguageSwitcher from '../LanguageSwitcher/LanguageSwitcher';
+import { usePWAInstall } from '../../hooks/usePWAInstall';
+import { useTranslation } from '../../hooks/useTranslation';
 
 const Header: React.FC = () => {
+  const { isInstalled, isInstallable, promptInstall } = usePWAInstall();
+  const { t } = useTranslation();
+
+  const showInstallButton = isInstallable && !isInstalled;
+
   return (
     <header className="Header">
       <div className="Header-Container">
@@ -12,6 +19,19 @@ const Header: React.FC = () => {
           <span className="Header-Name">LPlates</span>
         </div>
         <div className="Header-Actions">
+          {showInstallButton && (
+            <button
+              className="Header-InstallButton"
+              onClick={promptInstall}
+              aria-label={t('app.install.installApp')}
+              title={t('app.install.installApp')}
+            >
+              <span className="Header-InstallButtonIcon">⬇️</span>
+              <span className="Header-InstallButtonLabel">
+                {t('app.install.installApp')}
+              </span>
+            </button>
+          )}
           <ThemeToggle />
           <LanguageSwitcher />
         </div>

--- a/src/components/LookupPanel/LookupPanel.tsx
+++ b/src/components/LookupPanel/LookupPanel.tsx
@@ -18,6 +18,7 @@ interface LookupPanelProps {
   onActiveChange?: (isActive: boolean) => void;
   externalQuery?: string;
   onScanClick?: () => void;
+  onMatchFound?: () => void;
 }
 
 const DEFAULT_CONTEXT = { t: (key: string) => key };
@@ -28,7 +29,8 @@ const LookupPanel: React.FC<LookupPanelProps> = React.memo(({
   onToggleFlags, 
   onActiveChange, 
   externalQuery,
-  onScanClick
+  onScanClick,
+  onMatchFound
 }) => {
   const languageContext = useContext(LanguageContext);
   const { t } = languageContext || DEFAULT_CONTEXT;
@@ -38,6 +40,8 @@ const LookupPanel: React.FC<LookupPanelProps> = React.memo(({
     const saved = localStorage.getItem(STORAGE_KEY);
     return saved ? JSON.parse(saved) : [];
   });
+
+  const matchFiredRef = React.useRef(false);
 
   const { codeIndex } = useRegionData(data);
 
@@ -87,6 +91,11 @@ const LookupPanel: React.FC<LookupPanelProps> = React.memo(({
   // side-effect: save to history (rerender-derived-state-no-effect)
   React.useEffect(() => {
     if (deferredDataList.length > 0 && deferredQuery.length >= 2) {
+      if (!matchFiredRef.current && onMatchFound) {
+        matchFiredRef.current = true;
+        onMatchFound();
+      }
+
       const trimmed = deferredQuery.trim().toUpperCase();
       
       setHistory(prev => {

--- a/src/components/PWAInstallPrompt/PWAInstallPrompt.css
+++ b/src/components/PWAInstallPrompt/PWAInstallPrompt.css
@@ -1,0 +1,147 @@
+.PWAInstallPrompt {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  padding: 1rem;
+  padding-top: 0;
+  padding-bottom: 0;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 400ms cubic-bezier(0.4, 0, 0.2, 1),
+              transform 400ms cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: none;
+}
+
+.PWAInstallPrompt_visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.PWAInstallPrompt_hiding {
+  opacity: 0;
+  transform: translateY(20px);
+  pointer-events: none;
+}
+
+.PWAInstallPrompt-Banner {
+  background: var(--color-glass-bg);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--color-glass-border);
+  border-radius: 16px 16px 0 0;
+  padding: 1.25rem;
+  position: relative;
+  box-shadow: 0 -4px 24px var(--color-shadow);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.PWAInstallPrompt-Close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: var(--color-surface-hover);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 16px;
+  transition: background 0.2s ease;
+}
+
+.PWAInstallPrompt-Close:hover {
+  background: var(--color-surface-active);
+}
+
+.PWAInstallPrompt-Content {
+  padding-right: 2rem;
+}
+
+.PWAInstallPrompt-Title {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 0.25rem;
+}
+
+.PWAInstallPrompt-Description {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
+}
+
+.PWAInstallPrompt-InstallButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.PWAInstallPrompt-InstallButton:hover {
+  transform: translateY(-1px);
+}
+
+.PWAInstallPrompt-InstallButton:active {
+  transform: translateY(0);
+}
+
+.PWAInstallPrompt-Steps {
+  background: var(--color-surface-hover);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
+.PWAInstallPrompt-Step {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.PWAInstallPrompt-Step + .PWAInstallPrompt-Step {
+  margin-top: 0.5rem;
+}
+
+.PWAInstallPrompt-StepNumber {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: rgba(0, 122, 255, 0.12);
+  color: #007AFF;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.PWAInstallPrompt-StepText {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--color-text);
+  line-height: 1.4;
+}
+
+.PWAInstallPrompt-StepIcon {
+  flex-shrink: 0;
+  color: #007AFF;
+}

--- a/src/components/PWAInstallPrompt/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt/PWAInstallPrompt.tsx
@@ -1,0 +1,127 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { usePWAInstall } from '../../hooks/usePWAInstall';
+import { useTranslation } from '../../hooks/useTranslation';
+import './PWAInstallPrompt.css';
+
+interface PWAInstallPromptProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+const PWAInstallPrompt: React.FC<PWAInstallPromptProps> = ({ visible, onClose }) => {
+  const { platform, isInstalled, isDismissed, promptInstall, dismiss } = usePWAInstall();
+  const { t } = useTranslation();
+  const [mounted, setMounted] = useState(false);
+  const [hiding, setHiding] = useState(false);
+  const closedRef = useRef(false);
+
+  const shouldBeVisible = visible && !isInstalled && !isDismissed;
+
+  useEffect(() => {
+    if (shouldBeVisible && !mounted) {
+      const raf = requestAnimationFrame(() => setMounted(true));
+      return () => cancelAnimationFrame(raf);
+    }
+    if (!shouldBeVisible) {
+      setMounted(false);
+    }
+  }, [shouldBeVisible]);
+
+  useEffect(() => {
+    closedRef.current = false;
+  }, [visible]);
+
+  const handleClose = () => {
+    setHiding(true);
+  };
+
+  const handleTransitionEnd = () => {
+    if (hiding && !closedRef.current) {
+      closedRef.current = true;
+      dismiss();
+      onClose();
+    }
+  };
+
+  if (!shouldBeVisible && !mounted) return null;
+
+  let visibilityClass = '';
+  if (hiding) {
+    visibilityClass = 'PWAInstallPrompt_hiding';
+  } else if (mounted) {
+    visibilityClass = 'PWAInstallPrompt_visible';
+  }
+
+  return (
+    <div
+      className={`PWAInstallPrompt ${visibilityClass}`}
+      role="dialog"
+      aria-label={t('app.install.title')}
+      onTransitionEnd={handleTransitionEnd}
+    >
+      <div className="PWAInstallPrompt-Banner">
+        <button
+          className="PWAInstallPrompt-Close"
+          onClick={handleClose}
+          aria-label={t('app.install.dismiss')}
+        >
+          ×
+        </button>
+
+        <div className="PWAInstallPrompt-Content">
+          {platform === 'ios' ? (
+            <>
+              <div className="PWAInstallPrompt-Title">
+                {t('app.install.addToHomeScreen')}
+              </div>
+              <div className="PWAInstallPrompt-Description">
+                {t('app.install.description')}
+              </div>
+              <div className="PWAInstallPrompt-Steps">
+                <div className="PWAInstallPrompt-Step">
+                  <span className="PWAInstallPrompt-StepNumber">1</span>
+                  <span className="PWAInstallPrompt-StepText">
+                    <svg className="PWAInstallPrompt-StepIcon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+                      <rect x="4" y="8" width="16" height="13" rx="2" fill="none" stroke="currentColor" strokeWidth="1.5" />
+                      <line x1="12" y1="8" x2="12" y2="3" stroke="currentColor" strokeWidth="1.5" />
+                      <polyline points="8,5 12,1 16,5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                    {t('app.install.iosStep1')}
+                  </span>
+                </div>
+                <div className="PWAInstallPrompt-Step">
+                  <span className="PWAInstallPrompt-StepNumber">2</span>
+                  <span className="PWAInstallPrompt-StepText">
+                    <svg className="PWAInstallPrompt-StepIcon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+                      <rect x="4" y="4" width="16" height="16" rx="4" fill="none" stroke="currentColor" strokeWidth="1.5" />
+                      <line x1="12" y1="8" x2="12" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                      <line x1="8" y1="12" x2="16" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                    </svg>
+                    {t('app.install.iosStep2')}
+                  </span>
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="PWAInstallPrompt-Title">
+                {t('app.install.title')}
+              </div>
+              <div className="PWAInstallPrompt-Description">
+                {t('app.install.description')}
+              </div>
+              <button
+                className="PWAInstallPrompt-InstallButton"
+                onClick={promptInstall}
+              >
+                {t('app.install.installButton')}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PWAInstallPrompt;

--- a/src/hooks/usePWAInstall.ts
+++ b/src/hooks/usePWAInstall.ts
@@ -1,0 +1,97 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+const STORAGE_KEY = 'pwa_install_dismissed';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+export type Platform = 'ios' | 'android' | 'desktop' | 'unknown';
+
+export interface UsePWAInstallResult {
+  isInstalled: boolean;
+  isInstallable: boolean;
+  platform: Platform;
+  isDismissed: boolean;
+  promptInstall: () => void;
+  dismiss: () => void;
+}
+
+function detectPlatform(): Platform {
+  if (typeof navigator === 'undefined') return 'unknown';
+  const ua = navigator.userAgent;
+  if (/(iPhone|iPad|iPod)/i.test(ua)) return 'ios';
+  if (/Android/i.test(ua)) return 'android';
+  if (/(Windows|Macintosh|Linux)/i.test(ua)) return 'desktop';
+  return 'unknown';
+}
+
+function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(display-mode: standalone)').matches;
+}
+
+export const usePWAInstall = (): UsePWAInstallResult => {
+  const [isInstalled, setIsInstalled] = useState<boolean>(() => isStandalone());
+  const [isInstallable, setIsInstallable] = useState<boolean>(false);
+  const [platform] = useState<Platform>(() => detectPlatform());
+  const [isDismissed, setIsDismissed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const deferredPromptRef = useRef<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    const handleBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault();
+      deferredPromptRef.current = e as BeforeInstallPromptEvent;
+      setIsInstallable(true);
+    };
+
+    const handleAppInstalled = () => {
+      setIsInstalled(true);
+      deferredPromptRef.current = null;
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    window.addEventListener('appinstalled', handleAppInstalled);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', handleAppInstalled);
+    };
+  }, []);
+
+  const promptInstall = useCallback(() => {
+    if (!deferredPromptRef.current) return;
+    deferredPromptRef.current.prompt();
+    deferredPromptRef.current.userChoice.then(() => {
+      deferredPromptRef.current = null;
+    }).catch(() => {
+      deferredPromptRef.current = null;
+    });
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setIsDismissed(true);
+    try {
+      localStorage.setItem(STORAGE_KEY, 'true');
+    } catch {
+      // localStorage not available — silently ignore
+    }
+  }, []);
+
+  return {
+    isInstalled,
+    isInstallable,
+    platform,
+    isDismissed,
+    promptInstall,
+    dismiss,
+  };
+};

--- a/src/locales/by.json
+++ b/src/locales/by.json
@@ -20,6 +20,16 @@
     "clearInput": "Ачысціць увод",
     "selectLanguage": "Выбраць мову",
     "recent": "Нядаўнія",
+    "install": {
+      "installApp": "Усталяваць дадатак",
+      "addToHomeScreen": "На галоўны экран",
+      "title": "Усталюйце LPlates",
+      "description": "Хуткі доступ без браўзера",
+      "installButton": "Усталяваць",
+      "dismiss": "Зачыніць",
+      "iosStep1": "Націсніце кнопку «Падзяліцца» у Safari",
+      "iosStep2": "Выберыце «На галоўны экран»"
+    },
     "clearHistory": "Ачысціць гісторыю",
     "theme": {
       "switchToDark": "Пераключыць на цёмную тэму",

--- a/src/locales/crh.json
+++ b/src/locales/crh.json
@@ -20,6 +20,16 @@
     "clearInput": "Киришни темизле",
     "selectLanguage": "Тилни сайла",
     "recent": "Сонъгъы",
+    "install": {
+      "installApp": "Къурулым",
+      "addToHomeScreen": "Баш экрангъа",
+      "title": "LPlates-ни къурунъыз",
+      "description": "Браузерсиз тез эришим",
+      "installButton": "Къур",
+      "dismiss": "Яб",
+      "iosStep1": "Safari-де «Пае этинъиз» дюгмесине басынъыз",
+      "iosStep2": "«Баш экрангъа» сайланъыз"
+    },
     "clearHistory": "Къыдырыш кечмишини темизле",
     "theme": {
       "switchToDark": "Къаранъгъы мевзугъа дегиштир",

--- a/src/locales/cz.json
+++ b/src/locales/cz.json
@@ -20,6 +20,16 @@
     "clearInput": "Vymazat vstup",
     "selectLanguage": "Vybrat jazyk",
     "recent": "Nedávné",
+    "install": {
+      "installApp": "Nainstalovat aplikaci",
+      "addToHomeScreen": "Na domovskou obrazovku",
+      "title": "Nainstalujte LPlates",
+      "description": "Rychlý přístup bez prohlížeče",
+      "installButton": "Nainstalovat",
+      "dismiss": "Zavřít",
+      "iosStep1": "Klepněte na tlačítko Sdílet v Safari",
+      "iosStep2": "Vyberte «Na plochu»"
+    },
     "clearHistory": "Vymazat historii",
     "theme": {
       "switchToDark": "Přepnout na tmavý motiv",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -21,6 +21,16 @@
     "clearInput": "Clear input",
     "selectLanguage": "Select language",
     "recent": "Recent",
+    "install": {
+      "installApp": "Install App",
+      "addToHomeScreen": "Add to Home Screen",
+      "title": "Install LPlates",
+      "description": "Get quick access without a browser",
+      "installButton": "Install",
+      "dismiss": "Close",
+      "iosStep1": "Tap the Share button in Safari",
+      "iosStep2": "Choose \"Add to Home Screen\""
+    },
     "clearHistory": "Clear history",
     "theme": {
       "switchToDark": "Switch to dark theme",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -20,6 +20,16 @@
     "clearInput": "Limpiar entrada",
     "selectLanguage": "Seleccionar idioma",
     "recent": "Recientes",
+    "install": {
+      "installApp": "Instalar aplicación",
+      "addToHomeScreen": "A la pantalla de inicio",
+      "title": "Instalar LPlates",
+      "description": "Acceso rápido sin navegador",
+      "installButton": "Instalar",
+      "dismiss": "Cerrar",
+      "iosStep1": "Toca el botón Compartir en Safari",
+      "iosStep2": "Elige \"A la pantalla de inicio\""
+    },
     "clearHistory": "Limpiar historial",
     "theme": {
       "switchToDark": "Cambiar a tema oscuro",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -21,6 +21,16 @@
     "clearInput": "Очистить ввод",
     "selectLanguage": "Выбрать язык",
     "recent": "Недавние",
+    "install": {
+      "installApp": "Установить приложение",
+      "addToHomeScreen": "На экран Домой",
+      "title": "Установите LPlates",
+      "description": "Быстрый доступ без браузера",
+      "installButton": "Установить",
+      "dismiss": "Закрыть",
+      "iosStep1": "Нажмите кнопку «Поделиться» в Safari",
+      "iosStep2": "Выберите «На экран Домой»"
+    },
     "clearHistory": "Очистить историю",
     "theme": {
       "switchToDark": "Переключить на темную тему",

--- a/src/locales/ua.json
+++ b/src/locales/ua.json
@@ -20,6 +20,16 @@
     "clearInput": "Очистити введення",
     "selectLanguage": "Вибрати мову",
     "recent": "Нещодавні",
+    "install": {
+      "installApp": "Встановити додаток",
+      "addToHomeScreen": "На екран Додому",
+      "title": "Встановіть LPlates",
+      "description": "Швидкий доступ без браузера",
+      "installButton": "Встановити",
+      "dismiss": "Закрити",
+      "iosStep1": "Натисніть кнопку «Поділитися» в Safari",
+      "iosStep2": "Оберіть «На екран Додому»"
+    },
     "clearHistory": "Очистити історію",
     "theme": {
       "switchToDark": "Перемкнути на темну тему",


### PR DESCRIPTION
Closes #51

## Summary

Adds an interactive PWA installation helper to improve user retention:

- **`usePWAInstall` hook** — platform detection (iOS/Android/desktop), `beforeinstallprompt` interception, standalone mode check, localStorage dismiss persistence
- **`PWAInstallPrompt` component** — glassmorphism bottom sheet with platform-specific UI:
  - Android/Desktop: Install button calling native prompt
  - iOS: 2-step visual instruction (Share → Add to Home Screen)
- **Header install button** — persistent button in Header-Actions for users who dismissed the prompt
- **Smart trigger** — prompt shows 1s after first successful search or camera scan (not on first load)
- **i18n** — translations for all 7 languages (en/ru/ua/cz/by/crh/es)
- **6 E2E Playwright tests**

### Verification
- TypeScript: 0 errors
- Vitest: 21/21 passed
- Build: successful