### PR TITLE
fix(ci): add .npmrc with legacy-peer-deps to resolve react-simple-maps peer conflict on deploy

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- `react-simple-maps@3.0.0` has peer dependency on React `^16.8.0 || 17.x || 18.x`, but project uses React 19
- `npm ci` on CI fails because it enforces peer dependency checks strictly
- Added `.npmrc` with `legacy-peer-deps=true` to bypass peer dependency validation

## Root cause
See CI log in #67 (current task). Local dev works because `npm install` is more lenient than `npm ci`.

## Note
This is a temporary workaround. A proper fix (replacing `react-simple-maps` with a React 19 compatible alternative) is tracked in #67.